### PR TITLE
Change the NodeFull fields to be public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ ureq = { version = "1.5.4", features = ["json"] }
 
 [dev-dependencies]
 base64 = "0.13.0"
+env_logger = "0.10"
+test-log = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0"
 slog-scope = "4.3"
 smart-default = "0.6.0"
 tokio = { version = "1.1.1", features = ["full"] }
+tracing = "0.1"
 ureq = { version = "1.5.4", features = ["json"] }
 
 [dev-dependencies]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   consul:
     container_name: consul
-    image: consul:1.9.3
+    image: consul:1.15.2
     command: >-
       consul
       agent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1274,13 +1274,15 @@ mod tests {
         let ResponseMeta { response, .. } = consul.get_service_nodes(req, None).await.unwrap();
         assert_eq!(response.len(), 3);
 
-        let addresses: Vec<String> = response.iter().map(|sn| sn.address.clone()).collect();
+        let addresses: Vec<String> = response
+            .iter()
+            .map(|sn| sn.service_address.clone().unwrap())
+            .collect();
         let expected_addresses = vec![
             "1.1.1.1".to_string(),
             "2.2.2.2".to_string(),
             "3.3.3.3".to_string(),
         ];
-        println!("addresses: {:?}", addresses);
         assert!(expected_addresses
             .iter()
             .all(|item| addresses.contains(item)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ use quick_error::quick_error;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use slog_scope::{error, info};
 use tokio::time::timeout;
+use tracing::trace;
 pub use types::*;
 
 mod hyper_wrapper;
@@ -762,6 +763,7 @@ impl Consul {
             )
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         let response = serde_json::from_slice::<GetServiceNodesResponse>(&bytes)
             .map_err(ConsulError::ResponseDeserializationFailed)?;
         Ok(ResponseMeta { response, index })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,7 @@ impl Consul {
             .execute_request(req, hyper::Body::empty(), None, READ_KEY_METHOD_NAME)
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         serde_json::from_slice::<Vec<ReadKeyResponse>>(&bytes)
             .map_err(ConsulError::ResponseDeserializationFailed)
     }
@@ -299,6 +300,7 @@ impl Consul {
             .execute_request(req, hyper::Body::empty(), None, READ_OBJ_METHOD_NAME)
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         serde_json::from_slice::<Vec<ReadKeyResponse<Base64Vec>>>(&bytes)
             .map_err(ConsulError::ResponseDeserializationFailed)?
             .into_iter()
@@ -352,6 +354,7 @@ impl Consul {
             )
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         Ok((
             serde_json::from_slice(&bytes).map_err(ConsulError::ResponseDeserializationFailed)?,
             index,
@@ -383,6 +386,7 @@ impl Consul {
             )
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         let resp = serde_json::from_slice::<Vec<TransactionResponse>>(&bytes)
             .map_err(ConsulError::ResponseDeserializationFailed)?;
         Ok(resp)
@@ -460,6 +464,7 @@ impl Consul {
             .execute_request(req, hyper::Body::empty(), None, DELETE_KEY_METHOD_NAME)
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         serde_json::from_slice(&bytes).map_err(ConsulError::ResponseDeserializationFailed)
     }
 
@@ -624,6 +629,7 @@ impl Consul {
             )
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         let service_tags_by_name = serde_json::from_slice::<HashMap<String, Vec<String>>>(&bytes)
             .map_err(ConsulError::ResponseDeserializationFailed)?;
 
@@ -649,6 +655,7 @@ impl Consul {
             .execute_request(request, hyper::Body::empty(), opts.timeout, GET_DATACENTERS)
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         let service_tags_by_name = serde_json::from_slice::<HashMap<String, Vec<String>>>(&bytes)
             .map_err(ConsulError::ResponseDeserializationFailed)?;
 
@@ -700,6 +707,7 @@ impl Consul {
             )
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         let mut response = serde_json::from_slice::<Vec<NodeFull>>(&bytes)
             .map_err(ConsulError::ResponseDeserializationFailed)?;
         if let Some(node) = response.pop() {
@@ -735,6 +743,7 @@ impl Consul {
             )
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         let response = serde_json::from_slice::<Vec<NodeFull>>(&bytes)
             .map_err(ConsulError::ResponseDeserializationFailed)?;
         Ok(ResponseMeta { response, index })
@@ -882,6 +891,7 @@ impl Consul {
             )
             .await?;
         let bytes = response_body.copy_to_bytes(response_body.remaining());
+        trace!(?bytes, "response from consul");
         serde_json::from_slice(&bytes).map_err(ConsulError::ResponseDeserializationFailed)
     }
 
@@ -981,6 +991,7 @@ impl Consul {
                 .await
                 .map_err(|e| ConsulError::UnexpectedResponseCode(status, e.to_string()))?;
             let bytes = response_body.copy_to_bytes(response_body.remaining());
+            trace!(?bytes, "response from consul");
             let resp = std::str::from_utf8(&*bytes)
                 .map_err(|e| ConsulError::UnexpectedResponseCode(status, e.to_string()))?;
             return Err(ConsulError::UnexpectedResponseCode(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1132,6 +1132,7 @@ fn record_duration_metric_if_enabled(_method: &Method, _function: &str, _duratio
 mod tests {
     use std::time::Duration;
 
+    use test_log::test;
     use tokio::time::sleep;
 
     use super::*;
@@ -1254,7 +1255,7 @@ mod tests {
         assert!(service_names_after_register.contains(&new_service_name.to_owned()));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
     async fn get_services_nodes() {
         let consul = get_client();
         let req = GetServiceNodesRequest {
@@ -1279,6 +1280,7 @@ mod tests {
             "2.2.2.2".to_string(),
             "3.3.3.3".to_string(),
         ];
+        println!("addresses: {:?}", addresses);
         assert!(expected_addresses
             .iter()
             .all(|item| addresses.contains(item)));

--- a/src/types.rs
+++ b/src/types.rs
@@ -580,7 +580,7 @@ pub struct Service {
     /// The address of the instance.
     pub address: String,
     /// The port of the instance.
-    pub port: u16,
+    pub port: Option<u16>,
 }
 
 pub(crate) fn serialize_duration_as_string<S>(

--- a/src/types.rs
+++ b/src/types.rs
@@ -530,24 +530,42 @@ pub struct Node {
 #[serde(rename_all = "PascalCase")]
 /// The node information as returned by the Consul Catalog API
 pub struct NodeFull {
-    id: String,
-    node: String,
-    address: String,
-    datacenter: String,
-    tagged_addresses: HashMap<String, String>,
-    node_meta: HashMap<String, String>,
-    create_index: u64,
-    modify_index: u64,
-    service_address: Option<String>,
-    service_enable_tag_override: Option<bool>,
+    /// The ID of the service node.
+    pub id: String,
+    /// The name of the Consul node on which the service is registered
+    pub node: String,
+    /// The IP address of the Consul node on which the service is registered.
+    pub address: String,
+    /// The datacenter where this node is running on.
+    pub datacenter: String,
+    /// List of explicit WAN and LAN addresses for the node
+    pub tagged_addresses: HashMap<String, String>,
+    /// Map of metadata options
+    pub node_meta: HashMap<String, String>,
+    /// The node's creation index, a unique identifier used for optimistic locking of the node
+    pub create_index: u64,
+    /// The node's last modified index, a unique identifier used for optimistic locking of the node
+    pub modify_index: u64,
+    /// IP address of the service host
+    pub service_address: Option<String>,
+    /// Indicates whether service tags can be overridden on this service
+    pub service_enable_tag_override: Option<bool>,
+
+    /// Unique service instance ID
     #[serde(rename = "Service_ID")]
-    service_id: Option<String>,
-    service_name: Option<String>,
-    service_port: Option<u16>,
-    service_meta: HashMap<String, String>,
-    service_tagged_addresses: HashMap<String, String>,
-    service_tags: Vec<String>,
-    namespace: Option<String>,
+    pub service_id: Option<String>,
+    /// The name of the service, i.e. redis.
+    pub service_name: Option<String>,
+    /// The port of the service
+    pub service_port: Option<u16>,
+    /// user defined metadata for the service
+    pub service_meta: HashMap<String, String>,
+    /// Map of explicit LAN and WAN addresses for the service instance
+    pub service_tagged_addresses: HashMap<String, String>,
+    /// List of tags for the service
+    pub service_tags: Vec<String>,
+    /// Consul enterprise namespace of the service
+    pub namespace: Option<String>,
 }
 
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -531,6 +531,7 @@ pub struct Node {
 /// The node information as returned by the Consul Catalog API
 pub struct NodeFull {
     /// The ID of the service node.
+    #[serde(rename = "ID")]
     pub id: String,
     /// The name of the Consul node on which the service is registered
     pub node: String,
@@ -561,11 +562,22 @@ pub struct NodeFull {
     /// user defined metadata for the service
     pub service_meta: HashMap<String, String>,
     /// Map of explicit LAN and WAN addresses for the service instance
-    pub service_tagged_addresses: HashMap<String, String>,
+    /// Note that the values could be either a string address or a port number
+    pub service_tagged_addresses: HashMap<String, TaggedAddress>,
     /// List of tags for the service
     pub service_tags: Vec<String>,
     /// Consul enterprise namespace of the service
     pub namespace: Option<String>,
+}
+
+/// A service address with an optional port.
+#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub struct TaggedAddress {
+    /// The address of the instance.
+    pub address: String,
+    /// The port of the instance.
+    pub port: Option<u16>,
 }
 
 #[derive(Clone, Debug, SmartDefault, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
# What problem are we solving?
The `NodeFull` fields were private and needed to be public to be accessible when returned.
# How are we solving the problem?
Changing the fields over to `pub` and adding documentation strings to them. I also changed the `port` field on `Service` to be optional because it seems consul sometimes doesn't return that information and the deserialization step fails. 

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
