### PR TITLE
Add URL encoding to filter queries and an additional catalog api function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ smart-default = "0.6.0"
 tokio = { version = "1.1.1", features = ["full"] }
 tracing = "0.1"
 ureq = { version = "1.5.4", features = ["json"] }
+urlencoding = "2.1.2"
 
 [dev-dependencies]
 base64 = "0.13.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ use slog_scope::{error, info};
 use tokio::time::timeout;
 use tracing::trace;
 pub use types::*;
+use urlencoding::encode;
 
 mod hyper_wrapper;
 /// The strongly typed data structures representing canonical consul objects.
@@ -910,7 +911,8 @@ impl Consul {
             url.push_str(&format!("?passing={}", request.passing));
         }
         if let Some(filter) = request.filter {
-            url.push_str(&format!("&filter={filter}"));
+            let filter = build_filter_string(filter);
+            url.push_str(&format!("&{filter}"));
         }
         add_query_option_params(&mut url, query_opts, '&');
         req.uri(url)
@@ -934,7 +936,8 @@ impl Consul {
             url.push_str(&format!("&near={near}"));
         }
         if let Some(filter) = request.filter {
-            url.push_str(&format!("&filter={filter}"));
+            let filter = build_filter_string(filter);
+            url.push_str(&format!("&{filter}"));
         }
         add_query_option_params(&mut url, query_opts, '&');
         req.uri(url)
@@ -1099,6 +1102,11 @@ fn add_query_param_separator(mut url: String, already_added: bool) -> String {
     }
 
     url
+}
+
+fn build_filter_string(filter: &str) -> String {
+    let filter = format!("filter=\"{}\"", filter);
+    encode(&filter).into_owned()
 }
 
 fn record_request_metric_if_enabled(_method: &Method, _function: &str) {


### PR DESCRIPTION
# What problem are we solving?
The filter query string wasn't being url encoded and was being sent to consul as plaintext. 
# How are we solving the problem?
Just added the url encoder and made a little helper function to create the encoded string.

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
