### PR TITLE
Make the Service port field optional

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   consul:
     container_name: consul
-    image: consul:1.11.11
+    image: consul:1.15.3
     command: >-
       consul
       agent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use std::{env, str::Utf8Error};
 use base64::Engine;
 use hyper::{body::Buf, client::HttpConnector, Body, Method};
 #[cfg(any(feature = "rustls-native", feature = "rustls-webpki"))]
-use hyper_rustls::{ HttpsConnector, HttpsConnectorBuilder };
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 #[cfg(feature = "default-tls")]
 use hyper_tls::HttpsConnector;
 use lazy_static::lazy_static;
@@ -251,7 +251,6 @@ where
 #[derive(Debug)]
 /// This struct defines the consul client and allows access to the consul api via method syntax.
 pub struct Consul {
-
     https_client: hyper::Client<HttpsConnector<HttpConnector>, Body>,
     config: Config,
     #[cfg(feature = "trace")]
@@ -275,7 +274,7 @@ fn https_connector() -> HttpsConnector<HttpConnector> {
     {
         let mut conn = HttpsConnector::new();
         conn.https_only(false);
-        return conn; 
+        return conn;
     }
 }
 
@@ -865,7 +864,7 @@ impl Consul {
         &self,
         service_name: &str,
         query_opts: Option<QueryOptions>,
-    ) -> Result<Vec<(String, u16)>> {
+    ) -> Result<Vec<(String, Option<u16>)>> {
         let request = GetServiceNodesRequest {
             service: service_name,
             passing: true,
@@ -903,12 +902,12 @@ impl Consul {
     /// in the health endpoint. These requests models are primarily for the
     /// health endpoints
     /// https://www.consul.io/api-docs/health#list-nodes-for-service
-    fn parse_host_port_from_service_node_response(sn: ServiceNode) -> (String, u16) {
+    fn parse_host_port_from_service_node_response(sn: ServiceNode) -> (String, Option<u16>) {
         (
             if sn.service.address.is_empty() {
                 info!(
-                    "Consul service {service_name} instance had an empty Service address, with port:{port}",
-                    service_name = &sn.service.service, port = sn.service.port
+                    "Consul service {} instance had an empty Service address, with port:{:?}",
+                    &sn.service.service, sn.service.port
                 );
                 sn.node.address
             } else {
@@ -1511,14 +1510,14 @@ mod tests {
             id: "node".to_string(),
             service: "node".to_string(),
             address: "2.2.2.2".to_string(),
-            port: 32,
+            port: Some(32),
         };
 
         let empty_service = Service {
             id: "".to_string(),
             service: "".to_string(),
             address: "".to_string(),
-            port: 32,
+            port: Some(32),
         };
 
         let sn = ServiceNode {

--- a/src/types.rs
+++ b/src/types.rs
@@ -532,6 +532,7 @@ pub struct Node {
 /// The node information as returned by the Consul Catalog API
 pub struct NodeFull {
     /// id
+    #[serde(rename = "ID")]
     pub id: String,
     /// node
     pub node: String,
@@ -561,7 +562,7 @@ pub struct NodeFull {
     /// service_meta
     pub service_meta: HashMap<String, String>,
     /// service_tagged_addresses
-    pub service_tagged_addresses: HashMap<String, String>,
+    pub service_tagged_addresses: HashMap<String, HashMap<String, serde_json::Value>>,
     /// service_tags
     pub service_tags: Vec<String>,
     ///  namespace

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,12 +25,9 @@ SOFTWARE.
 use std::collections::HashMap;
 use std::time::Duration;
 
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use serde::{self, de::Deserializer, de::Error as SerdeError, Deserialize, Serialize, Serializer};
 use smart_default::SmartDefault;
-use base64::{ 
-    Engine, 
-    engine::general_purpose::STANDARD as B64,
-};
 
 // TODO retrofit other get APIs to use this struct
 /// Query options for Consul endpoints.
@@ -536,7 +533,7 @@ pub struct Node {
 pub struct NodeFull {
     /// id
     pub id: String,
-    /// node 
+    /// node
     pub node: String,
     /// address
     pub address: String,
@@ -583,7 +580,7 @@ pub struct Service {
     /// The address of the instance.
     pub address: String,
     /// The port of the instance.
-    pub port: u16,
+    pub port: Option<u16>,
 }
 
 pub(crate) fn serialize_duration_as_string<S>(


### PR DESCRIPTION
# What problem are we solving? 
The port field of the Service struct isn't returned in consul version 1.15.2. I searched through the changelog on the consul GitHub page and found no reference to this being made optional at some point. The closest I see is: https://github.com/hashicorp/consul/blob/main/api/agent.go#L285C1-L286C1 which seems to show the field as optional but my understanding of Go is very limited. 
 
# How are we solving the problem?
I made the field optional again and tested against 1.15.2 and it works as expected. 

# Checks
Please check these off before promoting the pull request to non-draft status.
- [x] All CI checks are green.
- [x] I have reviewed the proposed changes myself.
